### PR TITLE
Fixes for the potential crashes and the compilation error on PER_MESH_BUFFERS code path.

### DIFF
--- a/src/vulkansponza.cpp
+++ b/src/vulkansponza.cpp
@@ -1446,7 +1446,7 @@ public:
 			vkCmdDrawIndexed(offScreenCmdBuffer, mesh.indexCount, 1, 0, 0, 0);
 		}
 
-		vkCmdBindPipeline(offScreenCmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineList->get("scene.blend"));
+		vkCmdBindPipeline(offScreenCmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, resources.pipelines->get("scene.blend"));
 
 		for (auto mesh : scene->meshes)
 		{

--- a/src/vulkansponza.cpp
+++ b/src/vulkansponza.cpp
@@ -1072,9 +1072,9 @@ public:
 		image.tiling = VK_IMAGE_TILING_OPTIMAL;
 		image.usage = usage | VK_IMAGE_USAGE_SAMPLED_BIT;
 
+		VkDedicatedAllocationImageCreateInfoNV dedicatedImageInfo{ VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV };
 		if (enableNVDedicatedAllocation)
 		{
-			VkDedicatedAllocationImageCreateInfoNV dedicatedImageInfo { VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV };
 			dedicatedImageInfo.dedicatedAllocation = VK_TRUE;
 			image.pNext = &dedicatedImageInfo;
 		}
@@ -1086,9 +1086,9 @@ public:
 		memAlloc.allocationSize = memReqs.size;
 		memAlloc.memoryTypeIndex = getMemTypeIndex(memReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
+		VkDedicatedAllocationMemoryAllocateInfoNV dedicatedAllocationInfo{ VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV };
 		if (enableNVDedicatedAllocation)
 		{
-			VkDedicatedAllocationMemoryAllocateInfoNV dedicatedAllocationInfo { VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV };
 			dedicatedAllocationInfo.image = attachment->image;
 			memAlloc.pNext = &dedicatedAllocationInfo;
 		}
@@ -1983,9 +1983,9 @@ public:
 		pipelineCreateInfo.pStages = shaderStages.data();
 		pipelineCreateInfo.flags = VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
 
+		VkPipelineRasterizationStateRasterizationOrderAMD rasterAMD{};
 		if (enableAMDRasterizationOrder)
 		{
-			VkPipelineRasterizationStateRasterizationOrderAMD rasterAMD{};
 			rasterAMD.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD;
 			rasterAMD.rasterizationOrder = VK_RASTERIZATION_ORDER_RELAXED_AMD;
 			rasterizationState.pNext = &rasterAMD;


### PR DESCRIPTION
**1.**
In the PER_MESH_BUFFERS code path:
`pipelineList->get("scene.blend")`
should be:
`resources.pipelines->get("scene.blend")`.

**2.**
I had a crash with the following code (VS2017, Windows SDK version 10.0.16299.0, crashed ONLY on Release build):
```
if (enableNVDedicatedAllocation)
{
    VkDedicatedAllocationImageCreateInfoNV dedicatedImageInfo {VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV };
    dedicatedImageInfo.dedicatedAllocation = VK_TRUE;
    image.pNext = &dedicatedImageInfo;
}
VK_CHECK_RESULT(vkCreateImage(device, &image, nullptr, &attachment->image));
```
It seems that `image.pNext` references to `dedicatedImageInfo` object which goes out of scope (and according to C++ language rules ends its lifetime). 

Excerpts from the C++ latest working draft ([N4713](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4713.pdf)):

> 6.6.4.3 Automatic storage duration [basic.stc.auto]
> 1 Block-scope variables not explicitly declared static, thread_local, or extern have automatic storage duration. The storage for these entities lasts until the block in which they are created exits. 2 [Note: These variables are initialized and destroyed as described in 9.7. —end note]

> 9.7 Declaration statement [stmt.dcl]
> ....
> 2 Variables with automatic storage duration (6.6.4.3) are initialized each time their declaration-statement is executed. Variables with automatic storage duration declared in the block are destroyed on exit from the block (9.6).
> 

It crashed in `vkCreateImage()`, the first usage of `image` create info struct after this block.
I found three instances of similar code. It was in NV and AMD extensions handling code - I fixed all but was able to test only on NV card. I don't have an access to AMD GPU.
